### PR TITLE
Fix high_availability_mode field deprecation and add documentation

### DIFF
--- a/new-cluster
+++ b/new-cluster
@@ -39,7 +39,7 @@ if [ ! -f cluster.json ]; then
 {
   "name": "$NAME",
   "openshift_version": "$VERSION",
-  "high_availability_mode": "None",
+  "control_plane_count": 1,
   "base_dns_domain": "$DOMAIN",
   "pull_secret": $PULL_SECRET
 }

--- a/sno/README.md
+++ b/sno/README.md
@@ -1,0 +1,3 @@
+# Installing OpenShift on a single node
+
+Make sure that the file permissions of `ssh-authorized-key-pub.txt` and `ssh-authorized-key.txt` are appropriate (e. g. 600 for the private and 644 for the public key).

--- a/sno/config
+++ b/sno/config
@@ -9,4 +9,5 @@ HETZNER_CREDS=#ws+vXiXYZUJ:WaRABC6t9Ln5Yn # notsecret
 SERVER=123456 # notsecret
 SERVER_HOSTNAME=your-hostname.your-server.de # notsecret
 
+# Make sure that your SSH public key is uploaded to Hetzner via the Web interface, because the installer will match the following fingerprint and add it to the server automatically.
 SSH_AUTHORIZED_KEY_FINGERPRINT=9e:4c:ab:cd:ef:b5:a4:ab:cd:ef:e4:ab:cd:ef:6e:d3 # notsecret


### PR DESCRIPTION
The high_availability_mode field is deprecated starting from April 2025, and is planned to be removed in three months. Red Hat will provide bug fixes and support for this feature during the current release lifecycle, but this feature will no longer receive enhancements and will be removed.

The alternative is to use control_plane_count instead. This change enables support for clusters with 4 or 5 control plane nodes, in addition to the previously supported configurations with 1 or 3 control plane nodes. The Assisted Installer supports 4 or 5 control plane nodes starting from OpenShift Container Platform version 4.18 and later.

https://docs.redhat.com/en/documentation/assisted_installer_for_openshift_container_platform/2025/html-single/installing_openshift_container_platform_with_the_assisted_installer/index#api-deprecation-notifications_about-ai